### PR TITLE
Add CI with Cypress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+env:
+  matrix:
+    secure: NgyU757dERrL7zixWBlJ2vyiBDfa3iNyH0YSfGyt4luZMU5QZ3IqzYX0jSEDNLL2Zc+GLzRphj5VQ4oPgoHvVSDQxMpQ/T/4zw/yjfKYNteZcIlWoLPO3a0IJBhKAkiNQeOxkUfWKqqrH7YDG/5oPpZfMpjbqR7j+qJ0tiiszfv2sWAJXsAWzJKnkMu4oPdQyosnsm8u5ZXYtau7LS1nitjFdzu24iqcYaSy3dhbPQkSTrhWCXBV0lFYvgopYQ2fmlZn2aae/kfuIrSzZ5NpB/n7uEXfJ6FhNyrPH1YcrhS3DtjP0QS+sS5C0xW00ZPRpLOJ6bUASmaolJUorYlcexcugnHHav6ePG4nbeUjTgo5Wi6V/MZ3pg1pJLgNfhxRIVFHG+MwzUMcR6wk5mHtmYToDiRu8v19IwLY+0hYVeIVq+PUassZDi2XwYhwiGhfmGMO0KicLXRYTnCjcPvGzZSXzyLqZgDilH29GVcsSBNirEL9GR+JE7mY3MWU+mYxzDHZ4jRw7a83mTaDd7Ouj+z8AL4vDIhwzQweOXBiehoxJOlMz4HO9HNUv9VLd0t3QePBJ2hlDBncw7InGsYcLhC/HWfV1/0xq7mn/AvH7cIKQs/KPmZKlZr3wBTNJt/heHM1+6rpU1+ALHrjl9neyTYSQXA4fxPy7cHnk7hWrKY=
+language: node_js
+node_js:
+  - 10
+cache:
+  directories:
+    - ~/.npm
+    - ~/.cache
+install:
+  - npm ci
+script:
+  - npm run travis

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a single-page app consisting mainly of two views: a home page listing some blog posts and a detail view for each post. Rather than go with a full-blown single-page-app framework like Angular or Ember, I've chosen to use a web-component compiler called [Stencil](https://stenciljs.com/) to create a few components, add a bit of routing, fold in [Redux](https://redux.js.org/) for state, and test it all with a tool called [Cypress](https://www.cypress.io/).
 
+[![Build Status](https://travis-ci.org/cnunciato/stencil-web-app-example.svg?branch=master)](https://travis-ci.org/cnunciato/stencil-web-app-example)
+
 ## Installing and Running This App
 
 1. First, install the [current version of Node](https://nodejs.org/en/). (The project requires Node 10 with NPM 6.) If you're [an `nvm` user](https://github.com/creationix/nvm), just run:

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:3333"
+  "baseUrl": "http://localhost:3333",
+  "projectId": "nkc1je"
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "build": "stencil build --prerender",
     "cypress:open": "concurrently --success first --kill-others 'npm run server' 'cypress open'",
     "cypress:run": "concurrently --success first --kill-others 'npm run server' 'cypress run'",
+    "cypress:ci": "concurrently --success first --kill-others 'npm run server' 'cypress run --record'",
     "start": "concurrently --success first 'npm run api' 'wait-on http://localhost:3000 && npm run server'",
     "server": "stencil build --dev --serve --watch --es5",
     "test": "npm run cypress:run",
+    "travis": "npm run cypress:ci",
     "dev": "npm run cypress:open"
   },
   "dependencies": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,8 +8,8 @@
 import '@stencil/core';
 
 import '@stencil/router';
-import '@stencil/redux';
 import '@stencil/state-tunnel';
+import '@stencil/redux';
 import {
   ActiveRouter,
   MatchResults,


### PR DESCRIPTION
This adds some Travis configuration to run the Cypress end-to-end tests and record the results in the Cypress dashboard.

Signed-off-by: Christian Nunciato <chris@nunciato.org>